### PR TITLE
#23 Using '_' instead of '-' in role name

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 
 Have you read Idealista's Code of Conduct? By filling an Issue, you are expected to comply with it,
- including treating everyone with respect: https://github.com/idealista/idealista/blob/master/CODE_OF_CONDUCT.md
+ including treating everyone with respect: https://github.com/idealista/zanata_role/blob/master/CODE_OF_CONDUCT.md
 
 -->
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tests/__pycache__
 .molecule
 .vagrant
 .cache
+.python-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/zanata_role/tree/develop)
 ### Changed
-- *[#23](https://github.com/idealista/zanata_role/issues/23) Using "_" instead of "-" in role name* @dortegau
+- *[#23](https://github.com/idealista/zanata_role/issues/23) * @dortegau
 
 ## [1.3.0](https://github.com/idealista/zanata_role/tree/1.3.0)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,33 +3,35 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
-## [Unreleased](https://github.com/idealista/zanata-role/tree/develop)
+## [Unreleased](https://github.com/idealista/zanata_role/tree/develop)
+### Changed
+- *[#23](https://github.com/idealista/zanata_role/issues/23) Using "_" instead of "-" in role name* @dortegau
 
-## [1.3.0](https://github.com/idealista/zanata-role/tree/1.3.0)
+## [1.3.0](https://github.com/idealista/zanata_role/tree/1.3.0)
 ### Added
-- *[#17](https://github.com/idealista/zanata-role/issues/17) Configure management access* @jmonterrubio
+- *[#17](https://github.com/idealista/zanata_role/issues/17) Configure management access* @jmonterrubio
 
-## [1.2.0](https://github.com/idealista/zanata-role/tree/1.2.0)
+## [1.2.0](https://github.com/idealista/zanata_role/tree/1.2.0)
 ### Fixed
 - *Removing possibility to disable autoscan* @dortegau
 
 ### Added
 - *JVM could be configured providing custom standalone.conf file* @dortegau
 
-## [1.1.0](https://github.com/idealista/zanata-role/tree/1.1.0)
+## [1.1.0](https://github.com/idealista/zanata_role/tree/1.1.0)
 
 ### Added
-- *[#10](https://github.com/idealista/zanata-role/issues/10) Updating Zanata version to latest release (4.2.1)* @dortegau
+- *[#10](https://github.com/idealista/zanata_role/issues/10) Updating Zanata version to latest release (4.2.1)* @dortegau
 
-## [1.0.1](https://github.com/idealista/zanata-role/tree/1.0.1)
+## [1.0.1](https://github.com/idealista/zanata_role/tree/1.0.1)
 
 ### Fixed
-- *[#6](https://github.com/idealista/zanata-role/issues/6) Fixing log level* @jdvr
-- *[#3](https://github.com/idealista/zanata-role/issues/3) Adding username to metadata dependencies* @dortegau
-- *[#1](https://github.com/idealista/zanata-role/issues/1) Fix landrush config* @dortegau
+- *[#6](https://github.com/idealista/zanata_role/issues/6) Fixing log level* @jdvr
+- *[#3](https://github.com/idealista/zanata_role/issues/3) Adding username to metadata dependencies* @dortegau
+- *[#1](https://github.com/idealista/zanata_role/issues/1) Fix landrush config* @dortegau
 
 
-## [1.0.0](https://github.com/idealista/zanata-role/tree/1.0.0)
+## [1.0.0](https://github.com/idealista/zanata_role/tree/1.0.0)
 
 ### Added
 - *First release*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 
 ## [Unreleased](https://github.com/idealista/zanata_role/tree/develop)
 ### Changed
-- *[#23](https://github.com/idealista/zanata_role/issues/23) * @dortegau
+- *[#23](https://github.com/idealista/zanata_role/issues/23) Using '_' instead of '-' in role name* @dortegau
 
 ## [1.3.0](https://github.com/idealista/zanata_role/tree/1.3.0)
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ See also the list of [contributors](https://github.com/idealista/zanata_role/con
 
 ![Apache 2.0 License](https://img.shields.io/hexpm/l/plug.svg)
 
-This project is licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license - see the [LICENSE](LICENSE.txt) file for details.
+This project is licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![Logo](https://raw.githubusercontent.com/idealista/zanata_role/master/logo.gif)
 
-# Zanata Ansible Role [![Build Status](https://travis-ci.org/idealista/zanata_role.png)](https://travis-ci.org/idealista/zanata_role)
+# Zanata Ansible Role 
+[![Build Status](https://travis-ci.org/idealista/zanata_role.png)](https://travis-ci.org/idealista/zanata_role)
+[![Ansible Galaxy](https://img.shields.io/badge/galaxy-idealista.zanata__role-B62682.svg)](https://galaxy.ansible.com/idealista/zanata_role)
 
 This Ansible role installs a Zanata server in a Debian environment. Based on the instructions present in [Zanata Platform Documentation](http://docs.zanata.org/en/latest/user-guide/system-admin/configuration/installation/).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ These instructions will get you a copy of the role for your Ansible Playbook. On
 Ansible 2.4.1.0 version installed.
 Inventory destination should be a Debian environment.
 
-For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Vagrant](https://www.vagrantup.com/) as driver (with [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager) plugin) and [VirtualBox](https://www.virtualbox.org/) as provider.
+> :warning: This role asumes that [Java](https://github.com/idealista/java_role), [WildFly](https://github.com/idealista/wildfly-role) and [MySQL](https://github.com/idealista/mysql_role) are previously installed. 
+
+For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Vagrant](https://www.vagrantup.com/) as driver (with [vagrant-hostmanager](https://github.com/devopsgroup-io/vagrant-hostmanager) plugin) and [VirtualBox](https://www.virtualbox.org/) as provider. Docker could be used as driver too.
 
 ### Installing
 
@@ -58,7 +60,7 @@ Look to the [defaults](defaults/main.yml) properties file to see the possible co
 
 ## Testing
 
-Execute ``` molecule test ``` under zanata_role folder to run the automated tests suite.
+Execute `$ molecule test` under zanata_role folder to run the automated tests suite.
 
 ## Built With
 
@@ -78,6 +80,6 @@ See also the list of [contributors](https://github.com/idealista/zanata_role/con
 
 ## License
 
-![Apache 2.0 Licence](https://img.shields.io/hexpm/l/plug.svg)
+![Apache 2.0 License](https://img.shields.io/hexpm/l/plug.svg)
 
-This project is licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license - see the [LICENSE.txt](LICENSE.txt) file for details.
+This project is licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license - see the [LICENSE](LICENSE.txt) file for details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![Logo](https://raw.githubusercontent.com/idealista/zanata-role/master/logo.gif)
+![Logo](https://raw.githubusercontent.com/idealista/zanata_role/master/logo.gif)
 
-# Zanata Ansible Role [![Build Status](https://travis-ci.org/idealista/zanata-role.png)](https://travis-ci.org/idealista/zanata-role)
+# Zanata Ansible Role [![Build Status](https://travis-ci.org/idealista/zanata_role.png)](https://travis-ci.org/idealista/zanata_role)
 
 This Ansible role installs a Zanata server in a Debian environment. Based on the instructions present in [Zanata Platform Documentation](http://docs.zanata.org/en/latest/user-guide/system-admin/configuration/installation/).
 
@@ -30,7 +30,7 @@ For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Vagrant
 Create or add to your roles dependency file (e.g requirements.yml):
 
 ```
-- src: idealista/zanata-role
+- src: idealista/zanata_role
   version: 1.1.0
   name: zanata
 ```
@@ -56,7 +56,7 @@ Look to the [defaults](defaults/main.yml) properties file to see the possible co
 
 ## Testing
 
-Execute ``` molecule test ``` under zanata-role folder to run the automated tests suite.
+Execute ``` molecule test ``` under zanata_role folder to run the automated tests suite.
 
 ## Built With
 
@@ -64,7 +64,7 @@ Execute ``` molecule test ``` under zanata-role folder to run the automated test
 
 ## Versioning
 
-For the versions available, see the [tags on this repository](https://github.com/idealista/zanata-role/tags).
+For the versions available, see the [tags on this repository](https://github.com/idealista/zanata_role/tags).
 
 Additionaly you can see what change in each version in the [CHANGELOG.md](CHANGELOG.md) file.
 
@@ -72,7 +72,7 @@ Additionaly you can see what change in each version in the [CHANGELOG.md](CHANGE
 
 * **Idealista** - *Work with* - [idealista](https://github.com/idealista)
 
-See also the list of [contributors](https://github.com/idealista/zanata-role/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/idealista/zanata_role/contributors) who participated in this project.
 
 ## License
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-# handlers file for zanata-role
+# handlers file for zanata_role
 
 - name: restart zanata
   systemd:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 galaxy_info:
+  role_name: zanata_role
   company: Idealista S.A.U.
   description: Zanata role to install and configure this server
   min_ansible_version: 2.4.1.0

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -12,4 +12,4 @@
     - role: mysql
     - role: java
     - role: wildfly
-    - role: zanata-role
+    - role: zanata_role

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -6,6 +6,6 @@
   version: 1.3.0
   name: wildfly
 
-- src: idealista.java-role
+- src: idealista.java_role
   version: 2.0.1
   name: java


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

Coherence with role name requirements imposed by Ansible Galaxy (Both GitHub repo and Galaxy artifact has the same 'id').

### Possible Drawbacks

I don't know 😇

### Applicable Issues

#23
